### PR TITLE
Optimize floatVectorToFloatArray for improved performance

### DIFF
--- a/packages/core/lib/spz-wasm/cppBufferUtil.ts
+++ b/packages/core/lib/spz-wasm/cppBufferUtil.ts
@@ -16,7 +16,10 @@ export const floatVectorToFloatArray = (
   const size = vec.size();
   const floatOffset = pointer >> 2;
 
-  const copiedBuffer = wasmModule.HEAPF32.slice(floatOffset, floatOffset + size);
+  const copiedBuffer = wasmModule.HEAPF32.slice(
+    floatOffset,
+    floatOffset + size,
+  );
 
   if (enhancementFunc !== undefined) {
     for (let i = 0; i < size; i++) {

--- a/packages/core/lib/spz-wasm/cppBufferUtil.ts
+++ b/packages/core/lib/spz-wasm/cppBufferUtil.ts
@@ -4,18 +4,25 @@ import type { MainModule, VectorFloat32, VectorUInt8T } from "./build/main";
  * create new Float32Array from cpp FloatVector
  * @param wasmModule emscripten main module
  * @param vec cpp float32 vector
+ * @param enhancementFunc function accepting a number and returning a number to perform processing
  * @returns copied float32 array
  */
 export const floatVectorToFloatArray = (
   wasmModule: MainModule,
   vec: VectorFloat32,
-  enhancementFunc: (n: number) => number = (n) => n,
+  enhancementFunc?: (n: number) => number,
 ): Float32Array => {
   const pointer = wasmModule.vf32_ptr(vec);
   const size = vec.size();
+  const floatOffset = pointer >> 2;
 
-  const buffer = new Float32Array(wasmModule.HEAPF32.buffer, pointer, size);
-  const copiedBuffer = buffer.map(enhancementFunc);
+  const copiedBuffer = wasmModule.HEAPF32.slice(floatOffset, floatOffset + size);
+
+  if (enhancementFunc !== undefined) {
+    for (let i = 0; i < size; i++) {
+      copiedBuffer[i] = enhancementFunc(copiedBuffer[i]);
+    }
+  }
 
   return copiedBuffer;
 };


### PR DESCRIPTION
This changes the `floatVectorToFloatArray` function used heavily during loads to use a faster method for copying the memory from the emscripten context to JS context. This was impacting us during loads of large scenes in CesiumJS, and has resulted in about a full second faster load time with the Microsoft campus dataset.

## Key changes

* The function now uses `slice` to copy data from the WASM heap, which is more efficient and avoids mapping over the buffer by default.
* Moved from using a `map` to a `for-loop`. For small datasets, this doesn't matter, but when simultaneously loading multiple datasets, each with >4 million Gaussians, the additional overhead of `map` quickly becomes costly.
* The `enhancementFunc` parameter is now optional and only applied if defined, reducing unnecessary processing for the default case.

## Results

Per my own testing using this [sandcastle](http://localhost:8080/Apps/Sandcastle2/index.html#c=hVTrc9o4EP9XdMx9MFMQIYGkSUjalGtTKA4JoWnJMJMKecEC2eIk8bA7+d9v/crjyvU+eMa7+j1212vVaqReJtdarYUHhBGrFhAS6zNLfGYI4xyMwSzpqJBcGAOWNA6OjvYbh8QRU7LUYs0slMd6HLbBiFVAEUg9mLKVtBcpe5hKnpFxCaKuP7nkoi+6na9xp34lOqYTDpq83TnsLJbf79rdY4qgv73LBYI6+/eXg8Cd32yubuvCjbuyNxz4/eHI9i8/BaNor3kV8/37+d18FAwWozkXvXZ3eY9i7vxr7MazehKPvt+I/vzjgRtfNN3hYt8dXh3T2d3RhX17OP/QjKbsg9/78rAd9XjVQLPd+zLUurGNuuvrm1jGs3HpNOkuebgKjSVrARvQ2FAIG5I3fZfmnHGJp3FbhZaJEPS4VCE/EyohFrTG3ElBGWYxnWoVfFNaennCKVcSwmP5yTYzpIZDCDjayWp266vNJ80CMNegbwHr8rAeq1dw+oIAWwuh5+R+WTILDv4aCgk4e7MEbpV2xVaE5X/1KYrTpDlXeSDRI5fmO2VSjxT5JGV1VAygViMDLDUIsCjwiCc0ktK9kop5Jxkos7aJLK7aGWEbJmwxslfFg01Hh/x0LTue02g26o3j5nMfqWe1WsXVc5nminxeWfwMZCq2f4xL5A26BUtmxURIYaMEmbFwsfFT5kUgUIQ7hlEu+iI7DulzB/nbaQZ+JCANpA6/HeU7+rDe4fT78T9T6MN/FvA8nFd7hX9yIKxYg6HM85ycVM5Z2WfIk1QD8yK8MwJh4PQXvVipYKicouScVCniF3/NZ9QR4exaWO4PWDiDJxIpIC6zPrVqgEAWGmeP7pUr/weq1puvYW/3kFeE5ewl6+yRcIbmxMF/T+mnQSdbqCRQqWbOj4/JUbqjWGvRzgn582fKefyRK5UqpZaxkYTzROG9CJZKW7LS0qG0ZiFYSrwoTW2y4gscITcGeWGrVlBanlgT4Z3tuEIIl8wYPJmupLwVMYxL560a4l/R8gL7a9CSRQnEr5/3siSltFXD8FeWVUpOmH6h+A8):

 - In the best case, calls to `floatVectorToFloatArray` are improved by about 500 ms.
 - In the worst case, calls were only improved by 100 ms.
 - This results in about a 1 second overall reduction in full tileset load time.

## Testing

To test using the above sandcastle:

 1. Ensure your CesiumJS repo is ready for testing. (No files checked out, npm install run, etc.)
 1. Pull down this repo and run `pnpm`
 1. Use `pnpm build:all` to build.
 1. Run `npm link` from this folder.
 1. Go to the CesiumJS repo folder and run `npm link @spz-loader/core`. This will replace the npm package in CesiumJS with this local copy.
 1. Run `npm run start` and navigate to the [sandcastle](http://localhost:8080/Apps/Sandcastle2/index.html#c=hVTrc9o4EP9XdMx9MFMQIYGkSUjalGtTKA4JoWnJMJMKecEC2eIk8bA7+d9v/crjyvU+eMa7+j1212vVaqReJtdarYUHhBGrFhAS6zNLfGYI4xyMwSzpqJBcGAOWNA6OjvYbh8QRU7LUYs0slMd6HLbBiFVAEUg9mLKVtBcpe5hKnpFxCaKuP7nkoi+6na9xp34lOqYTDpq83TnsLJbf79rdY4qgv73LBYI6+/eXg8Cd32yubuvCjbuyNxz4/eHI9i8/BaNor3kV8/37+d18FAwWozkXvXZ3eY9i7vxr7MazehKPvt+I/vzjgRtfNN3hYt8dXh3T2d3RhX17OP/QjKbsg9/78rAd9XjVQLPd+zLUurGNuuvrm1jGs3HpNOkuebgKjSVrARvQ2FAIG5I3fZfmnHGJp3FbhZaJEPS4VCE/EyohFrTG3ElBGWYxnWoVfFNaennCKVcSwmP5yTYzpIZDCDjayWp266vNJ80CMNegbwHr8rAeq1dw+oIAWwuh5+R+WTILDv4aCgk4e7MEbpV2xVaE5X/1KYrTpDlXeSDRI5fmO2VSjxT5JGV1VAygViMDLDUIsCjwiCc0ktK9kop5Jxkos7aJLK7aGWEbJmwxslfFg01Hh/x0LTue02g26o3j5nMfqWe1WsXVc5nminxeWfwMZCq2f4xL5A26BUtmxURIYaMEmbFwsfFT5kUgUIQ7hlEu+iI7DulzB/nbaQZ+JCANpA6/HeU7+rDe4fT78T9T6MN/FvA8nFd7hX9yIKxYg6HM85ycVM5Z2WfIk1QD8yK8MwJh4PQXvVipYKicouScVCniF3/NZ9QR4exaWO4PWDiDJxIpIC6zPrVqgEAWGmeP7pUr/weq1puvYW/3kFeE5ewl6+yRcIbmxMF/T+mnQSdbqCRQqWbOj4/JUbqjWGvRzgn582fKefyRK5UqpZaxkYTzROG9CJZKW7LS0qG0ZiFYSrwoTW2y4gscITcGeWGrVlBanlgT4Z3tuEIIl8wYPJmupLwVMYxL560a4l/R8gL7a9CSRQnEr5/3siSltFXD8FeWVUpOmH6h+A8)

Note: Ensure you have `docker` installed and available on your path. If you are using `podman-docker`, you may need to add a SELinux tag (`z` or `Z`) to the `build:docker` script in `package.json`. (e.g. `docker run --rm -v $(pwd)/lib/spz-wasm/:/src:z emscripten/emsdk ./build.sh`)